### PR TITLE
Fix version errors and add debug option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ docs
 vendor
 coverage
 .idea
+.phpunit.result.cache
+graph.jpeg

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "doctrine/dbal": "^3.0",
         "phpdocumentor/graphviz": "^2.0",
         "nikic/php-parser":"^4.0"
@@ -24,7 +24,7 @@
     "require-dev": {
         "larapack/dd": "^1.0",
         "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^8.3|^9.0",
+        "phpunit/phpunit": "^9.0",
         "spatie/phpunit-snapshot-assertions": "^4.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.3 || ^8.0",
         "doctrine/dbal": "^3.0",
         "phpdocumentor/graphviz": "^2.0",
         "nikic/php-parser":"^4.0"

--- a/config/config.php
+++ b/config/config.php
@@ -25,16 +25,6 @@ return [
     ],
 
     /*
-     * If you want avoid checking certain methods in a model, you can specify them here.
-     * To skip enter the class name as the key and an array of method names to ignore.
-     */
-    'skip' => [
-        // Post::class => [
-        //     'method'
-        // ]
-    ],
-
-    /*
      * If you want to see only specific models, specify them here using fully qualified
      * classnames.
      *
@@ -65,6 +55,12 @@ return [
      * 'use_db_schema' to be set to true.
      */
     'use_column_types' => true,
+
+    /*
+     * This setting, if set to true, will make the generator print certain
+     * mode/relation errors.
+     */
+    'debug' => false,
 
     /*
      * These colors will be used in the table representation for each entity in

--- a/config/config.php
+++ b/config/config.php
@@ -25,6 +25,16 @@ return [
     ],
 
     /*
+     * If you want avoid checking certain methods in a model, you can specify them here.
+     * To skip enter the class name as the key and an array of method names to ignore.
+     */
+    'skip' => [
+        // Post::class => [
+        //     'method'
+        // ]
+    ],
+
+    /*
      * If you want to see only specific models, specify them here using fully qualified
      * classnames.
      *

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,16 +14,17 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+        </report>
+    </coverage>
     <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
 </phpunit>

--- a/src/Edge.php
+++ b/src/Edge.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\ErdGenerator;
 
 use phpDocumentor\GraphViz\Node;
+use phpDocumentor\GraphViz\Edge as Base;
 
 /**
  * Class Edge
@@ -11,7 +12,7 @@ use phpDocumentor\GraphViz\Node;
  * @method void setXLabel(string $name)
  *
  */
-class Edge extends \phpDocumentor\GraphViz\Edge
+class Edge extends Base
 {
     protected $fromPort = null;
 
@@ -20,9 +21,9 @@ class Edge extends \phpDocumentor\GraphViz\Edge
     /**
      * @param Node $from
      * @param Node $to
-     * @return Edge|\phpDocumentor\GraphViz\Edge
+     * @return Edge|Base
      */
-    public static function create(Node $from, Node $to): self
+    public static function create(Node $from, Node $to): Base
     {
         return new self($from, $to);
     }
@@ -48,7 +49,7 @@ class Edge extends \phpDocumentor\GraphViz\Edge
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $attributes = array();
         foreach ($this->attributes as $value) {

--- a/src/ModelRelation.php
+++ b/src/ModelRelation.php
@@ -11,7 +11,7 @@ class ModelRelation
     private $foreignKey;
     private $name;
 
-    public function __construct($name, $type, $model, $localKey = null, $foreignKey)
+    public function __construct($name, $type, $model, $localKey = null, $foreignKey = null)
     {
         $this->type = $type;
         $this->model = $model;

--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionMethod;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 
 
 class RelationFinder
@@ -95,7 +96,10 @@ class RelationFinder
                     )
                 ];
             }
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) {
+            Log::error("Error in model $model and method $method.");
+            Log::error($e->getMessage() . $e->getTraceAsString());
+        }
         return null;
     }
 

--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -29,10 +29,11 @@ class RelationFinder
             return Collection::make($trait->getMethods(ReflectionMethod::IS_PUBLIC));
         })->flatten();
 
+        $ignoreMethods = Arr::get(config('erd-generator.skip', []), $model, []);
         $methods = Collection::make($class->getMethods(ReflectionMethod::IS_PUBLIC))
             ->merge($traitMethods)
-            ->reject(function (ReflectionMethod $method) use ($model) {
-                return $method->class !== $model || $method->getNumberOfParameters() > 0;
+            ->reject(function (ReflectionMethod $method) use ($model, $ignoreMethods) {
+                return $method->class !== $model || $method->getNumberOfParameters() > 0 || in_array($method->getName(), $ignoreMethods);
             });
 
         $relations = Collection::make();
@@ -43,7 +44,7 @@ class RelationFinder
 
         $relations = $relations->filter();
 
-        if ($ignoreRelations = Arr::get(config('erd-generator.ignore', []),$model))
+        if ($ignoreRelations = Arr::get(config('erd-generator.ignore', []), $model))
         {
             $relations = $relations->diffKeys(array_flip($ignoreRelations));
         }

--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -29,11 +29,10 @@ class RelationFinder
             return Collection::make($trait->getMethods(ReflectionMethod::IS_PUBLIC));
         })->flatten();
 
-        $ignoreMethods = Arr::get(config('erd-generator.skip', []), $model, []);
         $methods = Collection::make($class->getMethods(ReflectionMethod::IS_PUBLIC))
             ->merge($traitMethods)
-            ->reject(function (ReflectionMethod $method) use ($model, $ignoreMethods) {
-                return $method->class !== $model || $method->getNumberOfParameters() > 0 || in_array($method->getName(), $ignoreMethods);
+            ->reject(function (ReflectionMethod $method) use ($model) {
+                return $method->class !== $model || $method->getNumberOfParameters() > 0;
             });
 
         $relations = Collection::make();
@@ -98,8 +97,10 @@ class RelationFinder
                 ];
             }
         } catch (\Throwable $e) {
-            Log::error("Error in model $model and method {$method->getName()}.");
-            Log::error($e->getMessage() . $e->getTraceAsString());
+            if (config('erd-generator.debug', false)) {
+                Log::error("Error in model $model and method {$method->getName()}.");
+                Log::error($e->getMessage() . $e->getTraceAsString());
+            }
         }
         return null;
     }

--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -98,7 +98,7 @@ class RelationFinder
                 ];
             }
         } catch (\Throwable $e) {
-            Log::error("Error in model $model and method $method.");
+            Log::error("Error in model $model and method {$method->getName()}.");
             Log::error($e->getMessage() . $e->getTraceAsString());
         }
         return null;

--- a/tests/FindModelsFromConfigTest.php
+++ b/tests/FindModelsFromConfigTest.php
@@ -7,6 +7,7 @@ use BeyondCode\ErdGenerator\Tests\Models\Avatar;
 use BeyondCode\ErdGenerator\Tests\Models\Comment;
 use BeyondCode\ErdGenerator\Tests\Models\Post;
 use BeyondCode\ErdGenerator\Tests\Models\User;
+use BeyondCode\ErdGenerator\Tests\Models\Error;
 
 class FindModelsFromConfigTest extends TestCase
 {
@@ -18,10 +19,10 @@ class FindModelsFromConfigTest extends TestCase
 
         $classNames = $finder->getModelsInDirectory(__DIR__ . "/Models");
 
-        $this->assertCount(4, $classNames);
+        $this->assertCount(5, $classNames);
 
         $this->assertSame(
-            [Avatar::class, Comment::class, Post::class, User::class],
+            [Avatar::class, Comment::class, Error::class, Post::class, User::class],
             $classNames->values()->all()
         );
     }
@@ -40,9 +41,9 @@ class FindModelsFromConfigTest extends TestCase
 
         $classNames = $finder->getModelsInDirectory(__DIR__ . "/Models");
 
-        $this->assertCount(3, $classNames);
+        $this->assertCount(4, $classNames);
         $this->assertEquals(
-            [Comment::class, Post::class, User::class],
+            [Comment::class, Error::class, Post::class, User::class],
             $classNames->values()->all()
         );
     }

--- a/tests/GenerationTest.php
+++ b/tests/GenerationTest.php
@@ -56,6 +56,6 @@ class GenerationTest extends TestCase
             '--format' => 'jpeg'
         ]);
 
-        $this->assertContains('Wrote diagram to graph.jpeg', Artisan::output());
+        $this->assertStringContainsString('Wrote diagram to graph.jpeg', Artisan::output());
     }
 }

--- a/tests/GetModelRelationsTest.php
+++ b/tests/GetModelRelationsTest.php
@@ -8,8 +8,9 @@ use BeyondCode\ErdGenerator\Tests\Models\Avatar;
 use BeyondCode\ErdGenerator\Tests\Models\Comment;
 use BeyondCode\ErdGenerator\Tests\Models\Post;
 use BeyondCode\ErdGenerator\Tests\Models\User;
+use BeyondCode\ErdGenerator\Tests\Models\Error;
 use Illuminate\Support\Arr;
-
+use Illuminate\Support\Facades\Log;
 
 class GetModelRelationsTest extends TestCase
 {
@@ -68,4 +69,14 @@ class GetModelRelationsTest extends TestCase
         $this->assertNull(Arr::get($relations, 'posts'));
     }
 
+    /** @test */
+    public function it_will_log_error_if_model_method_throws_exception()
+    {
+        $finder = new RelationFinder();
+        Log::spy();
+
+        $finder->getModelRelations(Error::class);
+
+        Log::shouldHaveReceived('error')->twice();
+    }
 }

--- a/tests/GetModelRelationsTest.php
+++ b/tests/GetModelRelationsTest.php
@@ -70,17 +70,12 @@ class GetModelRelationsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_skip_a_method_if_it_is_in_config_skip()
+    public function it_will_not_log_errors_if_debug_is_disabled()
     {
-        $this->app['config']->set('erd-generator.skip', [
-            Error::class => [
-                'error'
-            ]
-        ]);
+        $this->app['config']->set('erd-generator.debug', false);
         Log::spy();
 
         $finder = new RelationFinder();
-
         $relations = $finder->getModelRelations(Error::class);
 
         Log::shouldNotHaveReceived('error');
@@ -88,11 +83,12 @@ class GetModelRelationsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_log_error_if_model_method_throws_exception()
+    public function it_will_log_errors_if_debug_is_enabled()
     {
-        $finder = new RelationFinder();
+        $this->app['config']->set('erd-generator.debug', true);
         Log::spy();
 
+        $finder = new RelationFinder();
         $finder->getModelRelations(Error::class);
 
         Log::shouldHaveReceived('error')->twice();

--- a/tests/GetModelRelationsTest.php
+++ b/tests/GetModelRelationsTest.php
@@ -70,6 +70,24 @@ class GetModelRelationsTest extends TestCase
     }
 
     /** @test */
+    public function it_will_skip_a_method_if_it_is_in_config_skip()
+    {
+        $this->app['config']->set('erd-generator.skip', [
+            Error::class => [
+                'error'
+            ]
+        ]);
+        Log::spy();
+
+        $finder = new RelationFinder();
+
+        $relations = $finder->getModelRelations(Error::class);
+
+        Log::shouldNotHaveReceived('error');
+        $this->assertCount(1, $relations);
+    }
+
+    /** @test */
     public function it_will_log_error_if_model_method_throws_exception()
     {
         $finder = new RelationFinder();

--- a/tests/Models/Error.php
+++ b/tests/Models/Error.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BeyondCode\ErdGenerator\Tests\Models;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+
+class Error extends Model
+{
+
+    public function error()
+    {
+        throw new Exception('Expected exception');
+    }
+
+}

--- a/tests/Models/Error.php
+++ b/tests/Models/Error.php
@@ -7,10 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class Error extends Model
 {
-
     public function error()
     {
         throw new Exception('Expected exception');
     }
 
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 }

--- a/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models__1.txt
+++ b/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models__1.txt
@@ -38,6 +38,17 @@ dir="both"
 arrowhead="tee"
 arrowtail="crow"
 ]
+beyondcodeerdgeneratortestsmodelserror:id -> beyondcodeerdgeneratortestsmodelspost:error_id [
+label=" "
+xlabel="HasMany
+posts"
+color="#FCBF49"
+penwidth="1.8"
+fontname="Helvetica Neue"
+dir="both"
+arrowhead="crow"
+arrowtail="none"
+]
 beyondcodeerdgeneratortestsmodelspost:user_id -> beyondcodeerdgeneratortestsmodelsuser:id [
 label=" "
 xlabel="BelongsTo

--- a/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models__1.txt
+++ b/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models__1.txt
@@ -1,10 +1,8 @@
-<?php return 'Found 4 models.
+Found 5 models.
 Inspecting model relations.
 
- 1/4 [▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░]  25%
- 2/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░]  50%
- 3/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░]  75%
- 4/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%digraph "G" {
+ 1/5 [▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░]  20%
+ 5/5 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%digraph "G" {
 style="filled"
 bgcolor="#F7F7F7"
 fontsize="12"
@@ -116,6 +114,14 @@ margin="0"
 shape="rectangle"
 fontname="Helvetica Neue"
 ]
+"beyondcodeerdgeneratortestsmodelserror" [
+label=<<table width="100%" height="100%" border="0" margin="0" cellborder="1" cellspacing="0" cellpadding="10">
+<tr width="100%"><td width="100%" bgcolor="#d3d3d3"><font color="#333333">Error</font></td></tr>
+</table>>
+margin="0"
+shape="rectangle"
+fontname="Helvetica Neue"
+]
 "beyondcodeerdgeneratortestsmodelspost" [
 label=<<table width="100%" height="100%" border="0" margin="0" cellborder="1" cellspacing="0" cellpadding="10">
 <tr width="100%"><td width="100%" bgcolor="#d3d3d3"><font color="#333333">Post</font></td></tr>
@@ -141,4 +147,3 @@ shape="rectangle"
 fontname="Helvetica Neue"
 ]
 }
-';

--- a/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models_with_db_columns__1.txt
+++ b/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models_with_db_columns__1.txt
@@ -1,10 +1,8 @@
-<?php return 'Found 4 models.
+Found 5 models.
 Inspecting model relations.
 
- 1/4 [▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░]  25%
- 2/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░]  50%
- 3/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░]  75%
- 4/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%digraph "G" {
+ 1/5 [▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░]  20%
+ 5/5 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%digraph "G" {
 style="filled"
 bgcolor="#F7F7F7"
 fontsize="12"
@@ -125,6 +123,14 @@ margin="0"
 shape="rectangle"
 fontname="Helvetica Neue"
 ]
+"beyondcodeerdgeneratortestsmodelserror" [
+label=<<table width="100%" height="100%" border="0" margin="0" cellborder="1" cellspacing="0" cellpadding="10">
+<tr width="100%"><td width="100%" bgcolor="#d3d3d3"><font color="#333333">Error</font></td></tr>
+</table>>
+margin="0"
+shape="rectangle"
+fontname="Helvetica Neue"
+]
 "beyondcodeerdgeneratortestsmodelspost" [
 label=<<table width="100%" height="100%" border="0" margin="0" cellborder="1" cellspacing="0" cellpadding="10">
 <tr width="100%"><td width="100%" bgcolor="#d3d3d3"><font color="#333333">Post</font></td></tr>
@@ -165,4 +171,3 @@ shape="rectangle"
 fontname="Helvetica Neue"
 ]
 }
-';

--- a/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models_with_db_columns__1.txt
+++ b/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models_with_db_columns__1.txt
@@ -38,6 +38,17 @@ dir="both"
 arrowhead="tee"
 arrowtail="crow"
 ]
+beyondcodeerdgeneratortestsmodelserror:id -> beyondcodeerdgeneratortestsmodelspost:error_id [
+label=" "
+xlabel="HasMany
+posts"
+color="#FCBF49"
+penwidth="1.8"
+fontname="Helvetica Neue"
+dir="both"
+arrowhead="crow"
+arrowtail="none"
+]
 beyondcodeerdgeneratortestsmodelspost:user_id -> beyondcodeerdgeneratortestsmodelsuser:id [
 label=" "
 xlabel="BelongsTo

--- a/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models_with_db_columns_and_types__1.txt
+++ b/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models_with_db_columns_and_types__1.txt
@@ -1,10 +1,8 @@
-<?php return 'Found 4 models.
+Found 5 models.
 Inspecting model relations.
 
- 1/4 [▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░]  25%
- 2/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░]  50%
- 3/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░]  75%
- 4/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%digraph "G" {
+ 1/5 [▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░]  20%
+ 5/5 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%digraph "G" {
 style="filled"
 bgcolor="#F7F7F7"
 fontsize="12"
@@ -125,6 +123,14 @@ margin="0"
 shape="rectangle"
 fontname="Helvetica Neue"
 ]
+"beyondcodeerdgeneratortestsmodelserror" [
+label=<<table width="100%" height="100%" border="0" margin="0" cellborder="1" cellspacing="0" cellpadding="10">
+<tr width="100%"><td width="100%" bgcolor="#d3d3d3"><font color="#333333">Error</font></td></tr>
+</table>>
+margin="0"
+shape="rectangle"
+fontname="Helvetica Neue"
+]
 "beyondcodeerdgeneratortestsmodelspost" [
 label=<<table width="100%" height="100%" border="0" margin="0" cellborder="1" cellspacing="0" cellpadding="10">
 <tr width="100%"><td width="100%" bgcolor="#d3d3d3"><font color="#333333">Post</font></td></tr>
@@ -165,4 +171,3 @@ shape="rectangle"
 fontname="Helvetica Neue"
 ]
 }
-';

--- a/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models_with_db_columns_and_types__1.txt
+++ b/tests/__snapshots__/GenerationTest__it_generated_graphviz_for_test_models_with_db_columns_and_types__1.txt
@@ -38,6 +38,17 @@ dir="both"
 arrowhead="tee"
 arrowtail="crow"
 ]
+beyondcodeerdgeneratortestsmodelserror:id -> beyondcodeerdgeneratortestsmodelspost:error_id [
+label=" "
+xlabel="HasMany
+posts"
+color="#FCBF49"
+penwidth="1.8"
+fontname="Helvetica Neue"
+dir="both"
+arrowhead="crow"
+arrowtail="none"
+]
 beyondcodeerdgeneratortestsmodelspost:user_id -> beyondcodeerdgeneratortestsmodelsuser:id [
 label=" "
 xlabel="BelongsTo


### PR DESCRIPTION
## Reviewers 
@damian @cosmeoes 

## Description

Since php 8.0, params with default values have to be at end https://php.watch/versions/8.0/deprecate-required-param-after-optional

Also, phpunit 9.0 changed the config file structure and the assertStringContains method so I updated accordingly

## Tests

`composer test` output:
```
❯ composer test
> vendor/bin/phpunit
PHPUnit 9.5.19 #StandWithUkraine

Runtime:       PHP 8.0.14 with Xdebug 3.1.1
Configuration: /home/pulpo/Documents/repos/laravel-er-diagram-generator/phpunit.xml.dist

............                                                      12 / 12 (100%)

Time: 00:00.493, Memory: 48.00 MB

OK (12 tests, 35 assertions)

Generating code coverage report in Clover XML format ... done [00:00.003]

Generating code coverage report in HTML format ... done [00:00.020]
```
