### PR TITLE
String warnings fix

### DIFF
--- a/src/GraphBuilder.php
+++ b/src/GraphBuilder.php
@@ -22,7 +22,7 @@ class GraphBuilder
         $this->graph = new Graph();
 
         foreach (config('erd-generator.graph') as $key => $value) {
-            $this->graph->{"set${key}"}($value);
+            $this->graph->{"set{$key}"}($value);
         }
 
         $this->addModelsToGraph($models);
@@ -94,7 +94,7 @@ class GraphBuilder
         $node->setLabel($this->getModelLabel($eloquentModel, $label));
 
         foreach (config('erd-generator.node') as $key => $value) {
-            $node->{"set${key}"}($value);
+            $node->{"set{$key}"}($value);
         }
 
         $this->graph->setNode($node);
@@ -129,11 +129,11 @@ class GraphBuilder
         $edge->setXLabel($relation->getType() . PHP_EOL . $relation->getName());
 
         foreach (config('erd-generator.edge') as $key => $value) {
-            $edge->{"set${key}"}($value);
+            $edge->{"set{$key}"}($value);
         }
 
         foreach (config('erd-generator.relations.' . $relation->getType(), []) as $key => $value) {
-            $edge->{"set${key}"}($value);
+            $edge->{"set{$key}"}($value);
         }
 
         $this->graph->link($edge);


### PR DESCRIPTION
### Reviewers

@damianed @carlos-silveira 

### Description

When updating to laravel 9 in https://github.com/Ptech21/chatbot-laravel/pull/1586, we got string warnings:
![image](https://user-images.githubusercontent.com/32235423/211383169-6e219df0-20c7-4a97-b3bb-a92e3abc2e67.png)

This fixes those.

### Tests

```
❯ composer test
> vendor/bin/phpunit
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.0 with PCOV 1.0.11
Configuration: /home/pulpo/Documents/repos/laravel-er-diagram-generator/phpunit.xml.dist

............                                                      12 / 12 (100%)

Time: 00:00.247, Memory: 48.00 MB

OK (12 tests, 35 assertions)

Generating code coverage report in Clover XML format ... done [00:00.002]

Generating code coverage report in HTML format ... done [00:00.018]
```